### PR TITLE
chore: upgrade sift to 0.3.1

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -3,5 +3,5 @@ export {
   jsx,
   serve,
   serveStatic,
-} from "https://deno.land/x/sift@0.2.0/mod.ts";
-export type { ComponentChild } from "https://deno.land/x/sift@0.2.0/mod.ts";
+} from "https://deno.land/x/sift@0.3.1/mod.ts";
+export type { ComponentChild } from "https://deno.land/x/sift@0.3.1/mod.ts";


### PR DESCRIPTION
serveStatic now serves appropriate content-type based on extension of the asset.